### PR TITLE
feat(#49): Refatoração das telas de cadastro e Listagem de Talhões/Fazendas

### DIFF
--- a/src/components/CadastroFazenda.vue
+++ b/src/components/CadastroFazenda.vue
@@ -122,7 +122,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, watch, defineProps } from 'vue';
+import { ref, onMounted, watch } from 'vue';
 import { FloatLabel, InputText, Divider, Select, Toast } from 'primevue';
 import { useToast } from 'primevue/usetoast';
 import { useRoute, useRouter } from 'vue-router';
@@ -270,7 +270,7 @@ const cadastrarOuAtualizarFazenda = async () => {
     let fetchData = {};
 
     if (isEditing.value) {
-  
+
       fetchData = {
         nomeFazenda: nomeFazenda.value,
         estado: estadoSelecionado.value,

--- a/src/components/CadastroTalhao.vue
+++ b/src/components/CadastroTalhao.vue
@@ -71,7 +71,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, watch } from 'vue';
+import { ref, onMounted } from 'vue';
 import { FloatLabel, InputText, Divider, Select, Toast } from 'primevue';
 import { useToast } from 'primevue/usetoast';
 import { useRoute, useRouter } from 'vue-router';
@@ -174,7 +174,7 @@ onMounted(() => {
 });
 
 const cadastrarTalhao = async () => {
-  if (!fazendaSelecionada.value || !talhao.value || !cultura.value || !produtividadePorAno.value || !ano.value || !tipoSolo.value || !area.value) {
+  if (!fazendaSelecionada.value || !safra.value || !cultura.value || !produtividadePorAno.value || !ano.value || !tipoSolo.value || !area.value) {
     toast.add({ severity: 'error', summary: 'Erro', detail: 'Por favor, preencha todos os campos.', life: 3000 });
     return;
   }
@@ -208,4 +208,3 @@ const cadastrarTalhao = async () => {
   }
 };
 </script>
-

--- a/src/components/FazendaListComponent.vue
+++ b/src/components/FazendaListComponent.vue
@@ -47,10 +47,10 @@ const visualizarImagem = (id) => {
 
 const nomeFazendaSelecionada = computed(() => fazendaSelecionada.value?.nome);
 
-const abrirDialog = (data) => {
-  fazendaSelecionada.value = data
-  visibleExcluir.value = true
-};
+// const abrirDialog = (data) => {
+//   fazendaSelecionada.value = data
+//   visibleExcluir.value = true
+// };
 
   const confirmarExclusao = async () => {
   try {
@@ -156,7 +156,7 @@ const mostrarAlerta = (mensagem, tipo = 'success') => {
         </template>
       </Column>
 
-      <Column field="excluir" header="Excluir" class="p-1">
+      <!-- <Column field="excluir" header="Excluir" class="p-1">
         <template #body="{ data }">
           <div class="flex justify-center">
             <Button
@@ -167,7 +167,8 @@ const mostrarAlerta = (mensagem, tipo = 'success') => {
             </Button>
           </div>
         </template>
-      </Column>
+      </Column> -->
+
     </DataTable>
 
 

--- a/src/components/TalhaoListComponent.vue
+++ b/src/components/TalhaoListComponent.vue
@@ -1,8 +1,7 @@
 <script setup>
 import { DataTable,Column, Button, InputText, Tag, Toast  } from 'primevue';
 import { FilterMatchMode } from  '@primevue/core/api';
-import { ref, defineProps, computed, onMounted } from 'vue';
-import { RouterLink } from 'vue-router';
+import { ref, defineProps, computed } from 'vue';
 import Dialog from 'primevue/dialog';
 import { useRouter } from 'vue-router';
 
@@ -15,28 +14,12 @@ const TOKEN = localStorage.getItem('token');
 
 const router = useRouter();
 
-
-
 const props = defineProps({
   talhao: {
     type: Array,
     required: true
   }
 });
-
-const visualizarExcluir = ref(false);
-const visualizarEditar = ref(false);
-
-const verifyRole = (role) =>{
-  if (role == "Administrador"){
-    visualizarExcluir.value = true;
-    visualizarEditar.value=true;
-  }
-  else{
-    visualizarExcluir.value=false;
-    visualizarEditar.value=false
-  }
-}
 
 const filtros = ref({
   global: { value: null, matchMode: FilterMatchMode.CONTAINS }
@@ -47,10 +30,10 @@ const talhaoSelecionado = ref(null);
 
 const nomeTalhaoSelecionada = computed(() => talhaoSelecionado.value?.nome);
 
-const abrirDialog = (data) => {
-  talhaoSelecionado.value = data
-  visibleExcluir.value = true
-};
+// const abrirDialog = (data) => {
+//   talhaoSelecionado.value = data
+//   visibleExcluir.value = true
+// };
 
 const confirmarExclusao = async () => {
   try {
@@ -93,10 +76,6 @@ const visualizarImagem = (id) => {
   router.push({ path: '/visualizartalhao' });
 }
 
-onMounted(()=>{
-  const role = localStorage.getItem('role');
-  verifyRole(role)
-})
 
 </script>
 
@@ -128,7 +107,7 @@ onMounted(()=>{
 
   <Column field="nome" header="Nome" sortable class="p-1 min-w-40 max-w-40"/>
   <Column field="cultura" header="Cultura" sortable class="p-1"/>
-  <!-- <Column field="produtividade" header="Produtividade" sortable class="p-1"/> -->
+  <Column field="produtividade" header="Produtividade" sortable class="p-1"/>
   <Column field="area" header="Área" sortable class="p-1"/>
   <Column field="solo" header="Solo" sortable class="p-1"/>
   <Column field="cidade" header="Cidade" sortable class="p-1"/>
@@ -146,7 +125,7 @@ onMounted(()=>{
     <template #body="{ data }" >
       <div class="flex justify-center">
         <Button
-        @click="() => visualizarImagem(data.id)"
+        @click="() => visualizarImagem(data.idFazenda)"
         class="hover:text-gray-600 cursor-pointer p-1 m-1 px-2 bg-gray-400 text-white border-0 rounded shadow hover:bg-gray-300 transition">
         Visualizar
       </Button>
@@ -155,7 +134,7 @@ onMounted(()=>{
   </Column>
 
 
-  <Column v-if="visualizarEditar" field="editar" header="Editar" class="p-1">
+  <Column field="editar" header="Editar" class="p-1">
     <template #body="{ data }">
       <div class="flex justify-center">
         <Button
@@ -167,7 +146,7 @@ onMounted(()=>{
     </template>
   </Column>
 
-  <Column v-if="visualizarExcluir" field="excluir" header="Excluir" class="p-1">
+  <!-- <Column field="excluir" header="Excluir" class="p-1">
     <template #body="{ data }">
       <div class="flex justify-center">
         <Button
@@ -178,7 +157,7 @@ onMounted(()=>{
         </Button>
       </div>
     </template>
-  </Column>
+  </Column> -->
 
   </DataTable>
 

--- a/src/views/AreasAgricolasView.vue
+++ b/src/views/AreasAgricolasView.vue
@@ -22,7 +22,7 @@ const fetchFazendas = async () => {
     const data = await response.json();
 
     fazendas.value = data.map(fazenda => ({
-      id:fazenda.id,
+      id: fazenda.id,
       nome: fazenda.nomeFazenda,
       cidade: fazenda.cidadeNome,
       estado: fazenda.estado,
@@ -51,7 +51,7 @@ const fetchTalhoes = async () => {
         id: talhao.id,
         nome: fazenda ? fazenda.nome : 'Fazenda não encontrada',
         cultura: talhao.culturaNome,
-        produtividade: talhao.produtividadeAno || 0,
+        produtividade: talhao.produtividadeAno,
         area: talhao.area,
         solo: talhao.tipoSoloNome,
         cidade: fazenda ? fazenda.cidade : 'Cidade não encontrada',


### PR DESCRIPTION
# Alterações Relizadas:
- Inserção do campo "produtividade" na listagem de talhões (necessário alterações no backend)
- Remoção da checagem de permissão com base no cargo do usuário (listagem de talhões);
- Comentado o código responsável por excluir fazendas e talhões;
- Alteração/correção do botão "Visualizar Imagem": Enviando o id das áreas agrícolas(fazendas) e não mais dos talhões; Agora aparecendo as imagens das fazendas no mapa.

#### Para testes: Alterações realizadas nos componentes TalhaoListComponent, FazendaListComponent e AreaAgricolaView; Entrar na aba de áreas agrícolas.