### PR TITLE
feat(#53) criação da tela base de dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@primeuix/themes": "^1.0.0",
         "@tailwindcss/vite": "^4.0.14",
         "axios": "^1.8.3",
+        "chart.js": "^4.4.9",
         "client": "file:",
         "leaflet": "^1.9.4",
         "leaflet-draw": "^1.0.4",
@@ -980,6 +981,12 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@primeuix/styled": {
       "version": "0.5.0",
@@ -2025,6 +2032,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.9.tgz",
+      "integrity": "sha512-EyZ9wWKgpAU0fLJ43YAEIF8sr5F2W3LqbS40ZJyHIner2lY14ufqv2VMp69MAiZ2rpwxEUxEhIH/0U3xyRynxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/client": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@primeuix/themes": "^1.0.0",
     "@tailwindcss/vite": "^4.0.14",
     "axios": "^1.8.3",
+    "chart.js": "^4.4.9",
     "client": "file:",
     "leaflet": "^1.9.4",
     "leaflet-draw": "^1.0.4",

--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -1,5 +1,5 @@
 <template>
-  <footer class="bg-black h-5 flex items-center justify-center fixed bottom-0 w-full">
+  <footer class="bg-black h-5 flex items-center justify-center fixed bottom-0 w-full z-50">
     <p class="text-white text-xs">@Grupo Porygon - 2025</p>
   </footer>
 </template>

--- a/src/components/graficos/ProdutividadePizzaComponent.vue
+++ b/src/components/graficos/ProdutividadePizzaComponent.vue
@@ -1,0 +1,76 @@
+<script setup>
+import Chart from "primevue/chart";
+import { ref, watch, defineProps } from "vue";
+
+const props = defineProps({
+  valuesData: {
+    type: Object,
+    required: true
+  }
+});
+
+const chartData = ref({});
+const chartOptions = ref({});
+
+const colorPalette = [
+  '#1abc9c', '#2ecc71', '#3498db', '#9b59b6', '#34495e',
+  '#16a085', '#27ae60', '#2980b9', '#8e44ad', '#2c3e50',
+  '#f1c40f', '#e67e22', '#e74c3c', '#ecf0f1', '#95a5a6',
+  '#f39c12', '#d35400', '#c0392b', '#bdc3c7', '#7f8c8d',
+  '#ff6384', '#36a2eb', '#cc65fe', '#ffce56', '#66bb6a',
+  '#ef5350', '#ab47bc', '#ffa726', '#26c6da', '#d4e157'
+];
+
+const setChartData = () => {
+  return {
+    labels: props.valuesData.labels,
+    datasets: [
+      {
+        type: 'pie',
+        data: props.valuesData.data,
+        backgroundColor: colorPalette
+      }
+    ]
+  };
+};
+
+const setChartOptions = () => {
+  const documentStyle = getComputedStyle(document.documentElement);
+  const textColor = documentStyle.getPropertyValue('--p-text-color');
+
+  return {
+    maintainAspectRatio: false,
+    responsive: true,
+    plugins: {
+      title: {
+        display: true,
+        text: props.valuesData.title || 'Gráfico de Pizza',
+        font: { size: 15 },
+        color: textColor,
+        padding: { top: 20 },
+        position: 'bottom'
+      },
+      legend: {
+        labels: {
+          usePointStyle: true,
+          color: textColor
+        }
+      }
+    }
+  };
+};
+
+watch(() => props.valuesData, () => {
+  chartData.value = setChartData();
+  chartOptions.value = setChartOptions();
+}, { immediate: true });
+</script>
+
+<template>
+  <Chart
+    type="pie"
+    :data="chartData"
+    :options="chartOptions"
+    class="w-full h-full"
+  />
+</template>

--- a/src/components/graficos/ProgressoAnalistaComponent.vue
+++ b/src/components/graficos/ProgressoAnalistaComponent.vue
@@ -1,0 +1,116 @@
+
+<script setup>
+import Chart from 'primevue/chart';
+import { ref, onMounted, defineProps, computed } from "vue";
+
+const props = defineProps({
+  valuesData: {
+    type: Array,
+    required: true
+  }
+});
+
+const chartData = ref();
+const chartOptions = ref();
+
+const valueLabels = computed(() => props.valuesData.labels);
+const valuesPendentes = computed(() => props.valuesData.pendentes);
+const valuesAtribuidos = computed(() => props.valuesData.atribuidos);
+const valuesAprovados = computed(() => props.valuesData.aprovados);
+
+const setChartData = () =>  {
+
+    return {
+        labels: valueLabels.value,
+        datasets: [
+            {
+                type: 'bar',
+                label: 'Pendentes',
+                backgroundColor: 'rgb(249, 115, 22)',
+                data: valuesPendentes.value
+            },
+            {
+                type: 'bar',
+                label: 'Atribuidos',
+                backgroundColor: 'rgb(6, 182, 212)',
+                data: valuesAtribuidos.value
+            },
+            {
+                type: 'bar',
+                label: 'Aprovados',
+                backgroundColor: 'rgb(107, 114, 128)',
+                data: valuesAprovados.value
+            }
+        ]
+    };
+};
+const setChartOptions = () =>  {
+    const documentStyle = getComputedStyle(document.documentElement);
+    const textColor = documentStyle.getPropertyValue('--p-text-color');
+    const textColorSecondary = documentStyle.getPropertyValue('--p-text-muted-color');
+    const surfaceBorder = documentStyle.getPropertyValue('--p-content-border-color');
+
+    return {
+        indexAxis: 'y',
+        responsive:true,
+        maintainAspectRatio: false,
+        plugins: {
+            title:{
+              display: true,
+              text: "Progresso por Analistas",
+              font:{
+                size:25
+              },
+              color: textColor,
+              padding:{
+                bottom:15
+              }
+            },
+            tooltip: {
+                mode: 'index',
+                intersect: false
+            },
+            legend: {
+                labels: {
+                    color: textColor
+                },
+                position: 'bottom'
+            }
+        },
+        scales: {
+            x: {
+                stacked: true,
+                ticks: {
+                    color: textColorSecondary
+                },
+                grid: {
+                    display: true,
+                    color: surfaceBorder
+                }
+
+            },
+            y: {
+                stacked: true,
+                ticks: {
+                    color: textColorSecondary
+                },
+                grid: {
+                    display:false,
+                    color: surfaceBorder
+                }
+            }
+        }
+    };
+}
+
+onMounted(() => {
+    chartData.value = setChartData();
+    chartOptions.value = setChartOptions();
+});
+
+</script>
+
+
+<template>
+  <Chart type="bar" :data="chartData" :options="chartOptions" />
+</template>

--- a/src/components/graficos/StatusGeralComponent.vue
+++ b/src/components/graficos/StatusGeralComponent.vue
@@ -1,0 +1,90 @@
+<script setup>
+import Chart from 'primevue/chart';
+import { ref, onMounted, defineProps, computed} from "vue";
+
+const props = defineProps({
+  valuesList: {
+    type: Array,
+    required: true
+  }
+});
+
+const valuesLista = computed(() => props.valuesList);
+const chartData = ref();
+const chartOptions = ref();
+
+const setChartData = () => {
+    return {
+        labels: ['Pendentes', 'Atribuidos', 'Aprovados'],
+        datasets: [
+            {
+                label: 'Status',
+                data: valuesLista.value,
+                backgroundColor: ['rgb(249, 115, 22)', 'rgb(6, 182, 212)', 'rgb(107, 114, 128)'],
+                borderWidth: 1
+            }
+        ]
+    };
+};
+const setChartOptions = () => {
+    const documentStyle = getComputedStyle(document.documentElement);
+    const textColor = documentStyle.getPropertyValue('--p-text-color');
+    const textColorSecondary = documentStyle.getPropertyValue('--p-text-muted-color');
+    const surfaceBorder = documentStyle.getPropertyValue('--p-content-border-color');
+
+    return {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: {
+            title:{
+              display: true,
+              text: "Status Geral",
+              font:{
+                size:25,
+                weight:'bold',
+              },
+              color: textColor,
+              padding:{
+                bottom:15
+              }
+            },
+            legend: {
+                labels: {
+                    color: textColor
+                },
+                display: false
+            }
+        },
+        scales: {
+            x: {
+                ticks: {
+                    color: textColorSecondary
+                },
+                grid: {
+                    display:false,
+                    color: surfaceBorder
+                }
+            },
+            y: {
+                beginAtZero: true,
+                ticks: {
+                    color: textColorSecondary
+                },
+                grid: {
+                    color: surfaceBorder
+                }
+            }
+        }
+    };
+}
+
+onMounted(() => {
+    chartData.value = setChartData();
+    chartOptions.value = setChartOptions();
+});
+
+</script>
+
+<template>
+    <Chart type="bar" :data="chartData" :options="chartOptions" />
+</template>

--- a/src/views/DashboardView.vue
+++ b/src/views/DashboardView.vue
@@ -1,3 +1,118 @@
+<script setup>
+import DatePicker from 'primevue/datepicker';
+import { FloatLabel } from 'primevue';
+import { ref, computed } from "vue";
+import StatusGeralComponent from '@/components/graficos/StatusGeralComponent.vue';
+import ProgressoAnalistaComponent from '@/components/graficos/ProgressoAnalistaComponent.vue';
+import ProdutividadePizzaComponent from '@/components/graficos/ProdutividadePizzaComponent.vue';
+
+const dates = ref();
+
+//Ordem - pendente, atribuido, aprovado
+const valuesStatusGeral = ref([430,300,220]);
+
+const valuesProgressoAnalista = ref({
+  labels: ['Ana', 'Carlos', 'Rafaela'],
+  pendentes: [20, 15, 30],
+  atribuidos: [5, 10, 3],
+  aprovados: [12, 18, 14]
+});
+
+const valuesCultura = ref({
+  title: 'por Cultura',
+  labels: ['Milho', 'Soja', 'Cana-de-açúcar', 'Algodão', 'Feijão'],
+  data: [540, 325, 702, 198, 450]
+});
+
+// Dados para gráfico por Estado
+const valuesEstado = ref({
+  title: 'por Estado',
+  labels: ['São Paulo', 'Minas Gerais', 'Paraná', 'Bahia', 'Goiás'],
+  data: [320, 410, 275, 190, 360]
+});
+
+// Dados para gráfico por Solo
+const valuesSolo = ref({
+  title: 'por Tipo de Solo',
+  labels: ['Arenoso', 'Argiloso', 'Massapê', 'Latossolo', 'Glei'],
+  data: [200, 500, 300, 420, 180]
+});
+
+const culturaMaisProdutiva = computed(() => {
+  const maxIndex = valuesCultura.value.data.indexOf(Math.max(...valuesCultura.value.data));
+  return {
+    nome: valuesCultura.value.labels[maxIndex],
+    valor: valuesCultura.value.data[maxIndex]
+  };
+});
+
+// Estrutura para ranking dos estados
+const rankingEstados = computed(() => {
+  return valuesEstado.value.labels.map((label, i) => ({
+    estado: label,
+    valor: valuesEstado.value.data[i]
+  }));
+});
+</script>
+
 <template>
-<p>Dashboard</p>
+
+  <div class="h-full w-[90%] ml-[5%] mr-[5%] mb-10">
+    <div class="flex flex-col">
+
+      <div class="text-center p-2 mt-4 lg:mb-3 mb-1">
+        <p class="text-4xl font-semibold text-gray-800">Dashboard</p>
+      </div>
+
+      <hr class="border-gray-300 mb-4">
+
+      <div class="p-5 py-3 bg-white rounded-xl shadow min-h-fit">
+
+        <div class="pt-2">
+          <FloatLabel variant="on">
+            <DatePicker class="w-64 h-9" showButtonBar showIcon="true"  v-model="dates" selectionMode="range" :manualInput="false" />
+            <label for="on_label">Selecione o período</label>
+          </FloatLabel>
+        </div>
+
+        <hr class="border-gray-300 my-5">
+
+        <div class="w-full flex flex-wrap justify-between gap-10">
+          <StatusGeralComponent class="lg:w-[48%] lg:h-64" :valuesList="valuesStatusGeral"/>
+          <ProgressoAnalistaComponent class="lg:w-[48%] lg:h-64" :valuesData="valuesProgressoAnalista"/>
+
+          <label class="flex w-full justify-center lg:text-4xl text-2xl font-semibold text-gray-700">Produtividade Média</label>
+          <div class="flex overflow-x-scroll lg:overflow-hidden h-50 lg:w-full lg:h-64" >
+            <ProdutividadePizzaComponent  :valuesData="valuesCultura"/>
+            <ProdutividadePizzaComponent  :valuesData="valuesEstado"/>
+            <ProdutividadePizzaComponent  :valuesData="valuesSolo"/>
+          </div>
+
+          <div class="w-full flex flex-wrap gap-10 ">
+
+            <div class="bg-gray-100 p-4 rounded-lg shadow w-full sm:w-[48%] flex flex-col justify-center items-center">
+              <p class="lg:text-3xl text-lg font-semibold text-gray-700 mb-2">Cultura Mais Produtiva</p>
+              <p class="lg:text-2xl text-xl font-bold text-orange-400">{{ culturaMaisProdutiva.nome }}</p>
+              <p class="text-lg text-gray-600">{{ culturaMaisProdutiva.valor.toLocaleString('pt-BR') }}</p>
+            </div>
+
+            <div class="bg-gray-100 p-4 rounded-lg shadow w-full sm:w-[48%]">
+              <p class="text-xl font-semibold text-gray-700 mb-2">Ranking de Estados</p>
+              <ul>
+                <li v-for="(estado, index) in rankingEstados" :key="index" class="flex justify-between border-b py-1">
+                  <span>{{ estado.estado }}</span>
+                  <span>{{ estado.valor.toLocaleString('pt-BR') }}</span>
+                </li>
+              </ul>
+            </div>
+
+          </div>
+
+        </div>
+      </div>
+
+    </div>
+
+  </div>
+
 </template>


### PR DESCRIPTION
#53 
Criação da rota & layout base da tela "/dashboard" com seções distintas para os diferentes relatórios: 

- Status geral;
- Progresso por analista;
- Produtividade média;
- Ranking/cultura mais produtiva;

![image](https://github.com/user-attachments/assets/99ca664a-6b24-4983-bf82-efdcb923a5dd)
![image](https://github.com/user-attachments/assets/f38ef887-fbf8-46c5-b464-5cbb5d788429)
![image](https://github.com/user-attachments/assets/1d9b72c8-b5ae-4176-964b-37e1a21ebe30)

 Para testes: Dar um "npm install" antes de iniciar o frontend; Acessar a aba "Dashboard" no menu superior
